### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -199,7 +199,7 @@ If you experience problems with Sealang, `log them on GitHub`_. If you
 want to contribute code, please `fork the code`_ and `submit a pull request`_.
 
 .. _BeeWare suite: http://pybee.org
-.. _Read The Docs: http://sealang.readthedocs.org
+.. _Read The Docs: https://sealang.readthedocs.io
 .. _@pybeeware on Twitter: https://twitter.com/pybeeware
 .. _BeeWare Users Mailing list: https://groups.google.com/forum/#!forum/beeware-users
 .. _BeeWare Developers Mailing list: https://groups.google.com/forum/#!forum/beeware-developers

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ try:
             ),
         ],
         # if use nose.collector, many plugins not is avaliable
-        # see: http://nose.readthedocs.org/en/latest/setuptools_integration.html
+        # see: https://nose.readthedocs.io/en/latest/setuptools_integration.html
         test_suite='nose.collector',
         tests_require=['nose']
     )


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified. `https://sealang.readthedocs.io/` is a 404, seems like the project's Read the Docs isn't set up.
